### PR TITLE
Fix Zexion Location for Goofy

### DIFF
--- a/locations/(CoR).json
+++ b/locations/(CoR).json
@@ -353,7 +353,7 @@
                 "item_count": 1,
                 "visibility_rules": [],
                 "access_rules": [
-                    "^$dif|easy, QuickRun:3, AerialDodge:3, HighJump:3, Glide:3 ^$multiple|5|ReflectElement:3|ChickenLittle|Stitch|final|MagnetElement:2|Explosion|ThunderElement:2|FinishingLeap",
+                    "^$dif|easy, QuickRun:3, AerialDodge:3, HighJump:3, Glide:3, ^$multiple|5|ReflectElement:3|ChickenLittle|Stitch|final|MagnetElement:2|Explosion|ThunderElement:2|FinishingLeap",
                     "^$dif|easy, @Levels/Wisdom level 5, QuickRun:2, AerialDodge:3, HighJump:3, Glide:3, ^$multiple|5|ReflectElement:3|ChickenLittle|Stitch|final|MagnetElement:2|Explosion|ThunderElement:2|FinishingLeap",
                     "^$dif|easy, @Levels/Wisdom level 5, @Levels/Master level 5, AerialDodge:3, HighJump:3, Glide:3, ^$multiple|5|ReflectElement:3|ChickenLittle|Stitch|final|MagnetElement:2|Explosion|ThunderElement:2|FinishingLeap",
                     "^$dif|normal, QuickRun:2, AerialDodge:2, HighJump:2, Glide:3, ^$multiple|3|ReflectElement:3|ChickenLittle|Stitch|final|MagnetElement:2|Explosion|ThunderElement:2|FinishingLeap",

--- a/locations/(OC2).json
+++ b/locations/(OC2).json
@@ -78,7 +78,7 @@
                             {
                                 "name": "Zexion Bonus: Goofy Slot 1",
                                 "item_count": 1,
-                                "visibility_rules": ["opt_dgstats_yes", "opt_superbosses_yes", "opt_superbosses_no, opt_hide_locations_no", "opt_superbosses_no, opt_hide_locations_no"],
+                                "visibility_rules": ["opt_dgstats_yes, opt_superbosses_yes", "opt_dgstats_yes, opt_superbosses_no, opt_hide_locations_no"],
                                 "access_rules": ["^$dif|easy, ReflectElement:3, Guard, FireElement:3, SlideDash, FlashStep, @Levels/Final level 7, ^$any|Stitch|Genie|ChickenLittle|PeterPan, DonaldFlareForce, DonaldFantasia, QuickRun:3, SecondChance, OnceMore",
                                 "^$dif|normal, ReflectElement:3, Guard, FireElement:3, ^$any|SlideDash|FlashStep, @Levels/Final level 7, QuickRun:3, ^$any|DonaldFlareForce|DonaldFantasia",
                                 "^$dif|hard, ReflectElement, ^$any|SlideDash|FlashStep, @Levels/Final level 5, FIreElement:2, ^$any|DonaldFlareForce|DonaldFantasia, QuickRun:2"]
@@ -86,4 +86,5 @@
                         
                             ]
                             }
+
                             ]


### PR DESCRIPTION
needed a `dgstats` check alongside the superboss/exclusion checks