### PR TITLE
Fix poptracker release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,9 @@
-name: Release a poptracker pack
+name: Update versions.json on release
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v5
-      - name: Prepare release
-        run: cd ${GITHUB_WORKSPACE} && zip -r poptracker.zip .
-      - name: Get checksum
-        run: echo "sha256sum=$(sha256sum poptracker.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
-        id: checksum
-      - uses: ncipollo/release-action@v1
-        with:
-          artifacts: poptracker.zip
-          allowUpdates: true
-          prerelease: false
-          immutableCreate: true
-          omitBodyDuringUpdate: true
-          omitNameDuringUpdate: true
-    outputs:
-      sha256sum: ${{ steps.checksum.outputs.sha256sum }}
   autoupdate:
-    needs: [publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,19 +11,24 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: versions
+      - name: Download source archive
+        run: curl -L -o source.zip "https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.event.release.tag_name }}.zip"
+      - name: Get checksum
+        run: echo "sha256sum=$(sha256sum source.zip | awk '{print $1}')" >> $GITHUB_OUTPUT
+        id: checksum
       - name: Git config
         run: git config user.name "Automation" && git config user.email "automation@localhost"
       - name: Add to json
         run: |-
-          jq '.versions |= . + [{
-            "package_version": "${{ github.ref_name }}",
-            "download_url": "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/poptracker.zip",
-            "sha256": "${{ needs.publish.outputs.sha256sum }}",
+          jq '.versions |= [{
+            "package_version": "${{ github.event.release.tag_name }}",
+            "download_url": "https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.event.release.tag_name }}.zip",
+            "sha256": "${{ steps.checksum.outputs.sha256sum }}",
             "changelog": ["Check release notes"]
-          }]' versions.json > new_versions.json
+          }] + .' versions.json > new_versions.json
       - name: Move new versions in
         run: mv new_versions.json versions.json
       - name: Commit
-        run: git commit -am "Release new version"
+        run: git commit -am "Release ${{ github.event.release.tag_name }}"
       - name: Push
         run: git push origin HEAD:versions


### PR DESCRIPTION
Don't take care of the release itself, but react on release events instead. Turns out that:

1) Poptracker relies on the latest version to be at the top
 2) it also apparently doesn't rename things on download so we can't have the same name for different packs.